### PR TITLE
dynfu::measurement_pipeline_block: remove const

### DIFF
--- a/include/dynfu/measurement_pipeline_block.hpp
+++ b/include/dynfu/measurement_pipeline_block.hpp
@@ -103,7 +103,7 @@ namespace dynfu {
 			 *		A tuple of \ref pipeline_value objects representing a
 			 *		vertex map and corresponding normal map.
 			 */
-			virtual value_type operator () (const depth_device::value_type::element_type & frame, std::size_t width, std::size_t height, Eigen::Matrix3f k, value_type v=value_type{}) = 0;
+			virtual value_type operator () (depth_device::value_type::element_type & frame, std::size_t width, std::size_t height, Eigen::Matrix3f k, value_type v=value_type{}) = 0;
 		
 		
 	};


### PR DESCRIPTION
... because dynfu::pipeline_value::get() is permitted to mutate the
associated dynfu::pipeline_value, and therefore is unusable if const.
