### PR TITLE
dynfu::libigl & Link Time Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ else()
 	endif()
 endif()
 
-#	OpenCL and other miscellaneous frameworks for TSDF Viewer
+#	OpenCL and other miscellaneous frameworks for libigl
 if(APPLE)
 	add_linker_options(-framework OpenCL -framework CoreVideo -framework IOKit -framework Cocoa)
 else()
@@ -63,6 +63,21 @@ endif()
 if(WIN32)
 	include_directories("C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v7.5\\include")
 	link_directories("C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v7.5\\lib\\x64")
+endif()
+
+#	libigl-related code won't assemble on Windows without this (too many sections)
+#	It also seems to matter that this come before add_executable (doesn't
+#	show up if it comes after like everything else)
+if (WIN32)
+	add_compile_options("-Wa,-mbig-obj")
+endif()
+#	Try and workaround THIS issue with libigl and Windows headers
+#	The issue: The libigl source uses THIS as a variable, whereas
+#	certain Windows headers #define it to be something else
+#	These offending Windows headers aren't pulled in with
+#	WIN32_LEAN_AND_MEAN
+if (WIN32)
+	add_definitions(-DWIN32_LEAN_AND_MEAN)
 endif()
 
 add_library(dynfu SHARED
@@ -91,23 +106,25 @@ add_library(dynfu SHARED
 	src/whereami.cpp
 )
 
-#	tsdf_viewer won't assemble on Windows without this (too many sections)
-#	It also seems to matter that this come before add_executable (doesn't
-#	show up if it comes after like everything else)
-if (WIN32)
-	add_compile_options("-Wa,-mbig-obj")
+add_library(dynfu_libigl SHARED src/libigl.cpp)
+find_package(OpenGL REQUIRED)
+target_link_libraries(dynfu_libigl ${OPENGL_gl_LIBRARY} pthread)
+#	We link against GLFW using a DLL in bin on Windows so this flag
+#	isn't needed (and actually breaks everything)
+if (NOT WIN32)
+	target_link_libraries(dynfu_libigl glfw)
 endif()
-#	Try and workaround THIS issue with libigl and Windows headers
-#	The issue: The libigl source uses THIS as a variable, whereas
-#	certain Windows headers #define it to be something else
-#	These offending Windows headers aren't pulled in with
-#	WIN32_LEAN_AND_MEAN
+if (NOT APPLE AND NOT WIN32)
+	find_package(GLEW REQUIRED)
+	target_link_libraries(dynfu_libigl ${GLEW_LIBRARIES})
+endif()
+#	Special GLEW/GLFW linker nonsense on Windows
 if (WIN32)
- 	add_definitions(-DWIN32_LEAN_AND_MEAN)
- endif()
+	set_target_properties(dynfu_libigl PROPERTIES LINK_FLAGS "bin/glew32.dll bin/glfw3.dll bin/*opencv*.dll")
+endif()
 
 add_executable(client src/main.cpp)
-target_link_libraries(client dynfu boost_program_options)
+target_link_libraries(client dynfu dynfu_libigl boost_program_options)
 
 add_executable(tests
 	src/test/cpu_pipeline_value.cpp
@@ -132,23 +149,7 @@ target_link_libraries(tests dynfu)
 add_executable(tsdf_viewer
 	src/tsdf_viewer.cpp
 )
-find_package(OpenGL REQUIRED)
-target_link_libraries(tsdf_viewer dynfu ${OPENGL_gl_LIBRARY} pthread)
-#	We link against GLFW using a DLL in bin on Windows so this flag
-#	isn't needed (and actually breaks everything)
-if (NOT WIN32)
-	target_link_libraries(tsdf_viewer glfw)
-	target_link_libraries(client glfw)
-endif()
-if (NOT APPLE AND NOT WIN32)
-	find_package(GLEW REQUIRED)
-	target_link_libraries(tsdf_viewer ${GLEW_LIBRARIES})
-	target_link_libraries(client, ${GLEW_LIBRARIES})
-endif()
-#	Special GLEW/GLFW linker nonsense on Windows
-if (WIN32)
-	set_target_properties(tsdf_viewer client PROPERTIES LINK_FLAGS "bin/glew32.dll bin/glfw3.dll bin/*opencv*.dll")
-endif()
+target_link_libraries(tsdf_viewer dynfu dynfu_libigl)
 
 add_custom_target(tests_run ALL
 	COMMAND tests
@@ -159,11 +160,8 @@ add_custom_target(tests_run ALL
 
 #	Special OpenCV linker nonsense
 if(WIN32)
-	set_target_properties(dynfu tests PROPERTIES LINK_FLAGS "bin/*opencv*.dll")
+	set_target_properties(dynfu tests client PROPERTIES LINK_FLAGS "bin/*opencv*.dll")
 else()
 	execute_process(COMMAND pkg-config --libs opencv OUTPUT_VARIABLE OPENCV_PKGCONFIG OUTPUT_STRIP_TRAILING_WHITESPACE)
 	add_linker_options(${OPENCV_PKGCONFIG})
 endif()
-
-target_link_libraries(dynfu ${OPENGL_gl_LIBRARY} pthread)
-target_link_libraries(client ${OPENGL_gl_LIBRARY} pthread)

--- a/include/dynfu/libigl.hpp
+++ b/include/dynfu/libigl.hpp
@@ -1,0 +1,24 @@
+/**
+ *	\file
+ */
+
+
+#include <Eigen/Dense>
+
+
+namespace dynfu {
+
+
+	namespace libigl {
+
+
+		void viewer (const Eigen::MatrixXd & vertices, const Eigen::MatrixXi & faces);
+
+
+		void marching_cubes (const Eigen::VectorXd & scalar_field, const Eigen::MatrixXd & field_Points, std::size_t x, std::size_t y, std::size_t z, Eigen::MatrixXd & vertices, Eigen::MatrixXi & faces);
+
+
+	}
+
+
+}

--- a/src/libigl.cpp
+++ b/src/libigl.cpp
@@ -1,0 +1,31 @@
+#include <dynfu/libigl.hpp>
+#include <igl/copyleft/marching_cubes.h>
+#include <igl/viewer/Viewer.h>
+
+
+namespace dynfu {
+
+
+	namespace libigl {
+
+
+		void viewer (const Eigen::MatrixXd & vertices, const Eigen::MatrixXi & faces) {
+
+			igl::viewer::Viewer viewer;
+			viewer.data.set_mesh(vertices,faces);
+			viewer.launch();
+
+		}
+
+
+		void marching_cubes (const Eigen::VectorXd & scalar_field, const Eigen::MatrixXd & field_points, std::size_t x, std::size_t y, std::size_t z, Eigen::MatrixXd & vertices, Eigen::MatrixXi & faces) {
+
+			igl::copyleft::marching_cubes(scalar_field,field_points,x,y,z,vertices,faces);
+
+		}
+
+
+	}
+
+
+}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,14 +9,13 @@
 #include <dynfu/kinect_fusion_opencl_measurement_pipeline_block.hpp>
 #include <dynfu/kinect_fusion_opencl_pose_estimation_pipeline_block.hpp>
 #include <dynfu/kinect_fusion_opencl_update_reconstruction_pipeline_block.hpp>
+#include <dynfu/libigl.hpp>
 #include <dynfu/msrc_file_system_depth_device.hpp>
 #include <dynfu/opencl_depth_device.hpp>
 #include <dynfu/opencv_depth_device.hpp>
 #include <dynfu/optional.hpp>
 #include <dynfu/path.hpp>
 #include <dynfu/timer.hpp>
-#include <igl/copyleft/marching_cubes.h>
-#include <igl/viewer/Viewer.h>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -201,12 +200,8 @@ static void main_impl (int argc, char ** argv) {
 
     std::cout << "Running Marching Cubes..." << std::endl;
 
-    igl::copyleft::marching_cubes(S_,GV,tsdf_size,tsdf_size,tsdf_size,SV,SF);
-    igl::viewer::Viewer viewer;
-    viewer.data.set_mesh(SV,SF);
-    viewer.launch();
-
-
+    dynfu::libigl::marching_cubes(S_,GV,tsdf_size,tsdf_size,tsdf_size,SV,SF);
+    dynfu::libigl::viewer(SV,SF);
 
 }
 

--- a/src/tsdf_viewer.cpp
+++ b/src/tsdf_viewer.cpp
@@ -3,13 +3,11 @@
 #include <dynfu/filesystem.hpp>
 #include <dynfu/file_system_opencl_program_factory.hpp>
 #include <dynfu/kinect_fusion_opencl_update_reconstruction_pipeline_block.hpp>
+#include <dynfu/libigl.hpp>
 #include <dynfu/msrc_file_system_depth_device.hpp>
 #include <dynfu/opencl_depth_device.hpp>
 #include <dynfu/path.hpp>
 #include <Eigen/Dense>
-#include <igl/copyleft/marching_cubes.h>
-#include <igl/readOFF.h>
-#include <igl/viewer/Viewer.h>
 #include <cstdlib>
 #include <exception>
 #include <iostream>
@@ -103,10 +101,8 @@ void main_impl (int, char **) {
 
     std::cout << "Running Marching Cubes..." << std::endl;
 
-    igl::copyleft::marching_cubes(S_,GV,tsdf_width,tsdf_height,tsdf_depth,SV,SF);
-    igl::viewer::Viewer viewer;
-    viewer.data.set_mesh(SV,SF);
-    viewer.launch();
+    dynfu::libigl::marching_cubes(S_,GV,tsdf_width,tsdf_height,tsdf_depth,SV,SF);
+    dynfu::libigl::viewer(SV,SF);
 
 }
 


### PR DESCRIPTION
Created the dynfu::libigl namespace which contains extremely thin wrappers to libigl functions.  dynfu::libigl is linked into a separate shared library which allows it to be built/linked once and never touched again.

This greatly reduces link times for "client" and "tsdf_viewer".
