### PR TITLE
dynfu::kinect_fusion_opencl_pose_estimation_pipeline_block - Remove U…

### DIFF
--- a/src/kinect_fusion_opencl_pose_estimation_pipeline_block.cpp
+++ b/src/kinect_fusion_opencl_pose_estimation_pipeline_block.cpp
@@ -148,7 +148,6 @@ namespace dynfu {
 				parallel_sum_.set_arg(0,in);
 				parallel_sum_.set_arg(1,out);
 				q_.enqueue_nd_range_kernel(parallel_sum_,1,nullptr,&input_size,&group_size_);
-				q_.finish();
 
 				input_size=output_size;
 				using std::swap;
@@ -163,7 +162,6 @@ namespace dynfu {
 				serial_sum_.set_arg(1,std::uint32_t(input_size));
 				std::size_t serial_size(27);
 				q_.enqueue_nd_range_kernel(serial_sum_,1,nullptr,&serial_size,nullptr);
-				q_.finish();
 
 			}
 


### PR DESCRIPTION
…nneeded Calls to boost::compute::command_queue::finish

Added for debugging and never removed.

Closes #182.
